### PR TITLE
 Use requests library (which supports HTTP keep-alive), doubling download speed

### DIFF
--- a/gigapan_downloader.py
+++ b/gigapan_downloader.py
@@ -112,8 +112,8 @@ def download_tiles(out_folder, output_format, img_id, tiles_url, height_tiles, w
                         continue
 
                 if success == False:
-                    print("Max retries reached, aborting download. You can run the program again \
-                                  to continue from here")
+                    print("Max retries reached, aborting download. You can run the program again "
+                             "to continue from here")
                     return
 
                 fout = open(filename, "wb")
@@ -183,16 +183,16 @@ if __name__ == "__main__":
             description='Gigapan image downloader')
 
     parser.add_argument('img_name', type=str,
-            help='Name of image, should be obtained from the link: \
-                    http://gigapan.com/gigapans/[img_name]')
+            help='Name of image, should be obtained from the link: '
+                    'http://gigapan.com/gigapans/[img_name]')
 
     parser.add_argument('-l', '--req-level', type=int,
-            help='Requested resolution level. If unset, it will download at max resolution. Try \
-                    different levels with --dry-run to observe the image size.')
+            help='Requested resolution level. If unset, it will download at max resolution. Try '
+                    'different levels with --dry-run to observe the image size.')
 
     parser.add_argument('--dry-run', action="store_true",
-            help='Fetch image metadata without downloading images. Can be used \
-                        to observe the expected image size among other things.')
+            help='Fetch image metadata without downloading images. Can be used '
+                    'to observe the expected image size among other things.')
 
     parser.add_argument('--retries', type=int, default=5,
             help='Maximum amount of retries per image.')

--- a/gigapan_downloader.py
+++ b/gigapan_downloader.py
@@ -4,7 +4,7 @@
 #     gigapan_downloader.py -h
 #
 # Normally links are:
-#     http://gigapan.org/gigapans/<img_name>>
+#     http://gigapan.com/gigapans/<img_name>>
 #
 # if level is 0, max resolution will be used, try with different levels to see
 # the image resolution to download
@@ -145,7 +145,7 @@ def download_tiles(out_folder, output_format, img_id, tiles_url, height_tiles, w
 def main(img_name, req_level, out_folder, output_format, dry_run, retries):
     """If req_level is None, the maximum resolution will be used"""
 
-    response = urllib.request.urlopen(f"http://www.gigapan.org/gigapans/{img_name}.kml")
+    response = urllib.request.urlopen(f"http://www.gigapan.com/gigapans/{img_name}.kml")
     img_id, tiles_url, (max_width_px, max_height_px), tile_size_px = parse_kml(response.read())
 
     (max_width_tiles, max_height_tiles), max_level = calculate_max_size(
@@ -184,7 +184,7 @@ if __name__ == "__main__":
 
     parser.add_argument('img_name', type=str,
             help='Name of image, should be obtained from the link: \
-                    http://gigapan.org/gigapans/[img_name]')
+                    http://gigapan.com/gigapans/[img_name]')
 
     parser.add_argument('-l', '--req-level', type=int,
             help='Requested resolution level. If unset, it will download at max resolution. Try \

--- a/gigapan_downloader.py
+++ b/gigapan_downloader.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     parser.add_argument('--out_format', type=str, default="tif",
             help='Output format. Use "tif" or "psb".')
 
-    parser.add_argument('-o', '--out-folder', type=Path, default=Path("./downloaded/"),
+    parser.add_argument('-o', '--out-folder', type=Path, default=Path("downloaded/"),
             help='Output folder. It will be created if it does not exist.')
 
     args = parser.parse_args()

--- a/test.py
+++ b/test.py
@@ -24,9 +24,10 @@ def test_integration(mocker, img_name):
 
         return response
 
-    out_folder = "./test_results/"
+    out_folder = "test_results/"
 
     urllopen_mock = mocker.patch("urllib.request.urlopen", side_effect=urllopen)
-    gigapan_downloader.main(img_name, req_level=2, out_folder=out_folder)
+    gigapan_downloader.main(img_name, req_level=2, out_folder=Path(out_folder), output_format="tif",
+                            dry_run=False, retries=5)
 
     # assert Path(".", "downloads", );

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ def test_integration(mocker, img_name):
 
     def urllopen(url):
         response = mocker.Mock()
-        if url == f"http://www.gigapan.org/gigapans/{img_name}.kml":
+        if url == f"http://www.gigapan.com/gigapans/{img_name}.kml":
             response.read.return_value = Path(".", "test_data", f"{img_name}.kml").read_text()
 
         else:

--- a/test.py
+++ b/test.py
@@ -10,23 +10,23 @@ import re
 @pytest.mark.parametrize("img_name", ["130095", "0d54f8d3323a60308eb2ff9831edfe4a"])
 def test_integration(mocker, img_name):
 
-    def urllopen(url):
+    def urllopen(url, timeout=None):
         response = mocker.Mock()
         if url == f"http://www.gigapan.com/gigapans/{img_name}.kml":
-            response.read.return_value = Path(".", "test_data", f"{img_name}.kml").read_text()
+            response.text = Path("test_data", f"{img_name}.kml").read_text()
 
         else:
             assert re.fullmatch(r"http://gigapan.com/get_ge_tile/\d+/\d+/\d+/\d+.*", url)
-            response.read.return_value = Path(".", "test_data", "sample_tile.jpg").read_bytes()
-            response.status = 200
+            response.content = Path("test_data", "sample_tile.jpg").read_bytes()
+            response.status_code = 200
             if random.randrange(0, 5) == 0:
-                response.status = 404
+                response.status_code = 404
 
         return response
 
     out_folder = "test_results/"
 
-    urllopen_mock = mocker.patch("urllib.request.urlopen", side_effect=urllopen)
+    urllopen_mock = mocker.patch("requests.sessions.Session.get", side_effect=urllopen)
     gigapan_downloader.main(img_name, req_level=2, out_folder=Path(out_folder), output_format="tif",
                             dry_run=False, retries=5)
 


### PR DESCRIPTION
This version uses the newer _requests_ library (which calls _urllib3_) for HTTP download instead of the ancient _urllib.request_ library, resulting in a doubling of download speed, because the same connection is reused for all tiles. I also fixed a few other minor issues, recorded as separate commits.